### PR TITLE
Fix link to GitHub project in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repo will contain the WIP Hack Language Specification.
 
 This GitHub URL is:
 
-> [https://github.com/hhvm/hack-langspec](https://github.com/hack/hack-langspec)
+> [https://github.com/hhvm/hack-langspec](https://github.com/hhvm/hack-langspec)
 
 Pull requests, issue filings and comments are extremely welcome.
 


### PR DESCRIPTION
The current URL generates a 404 error.