### PR TITLE
disambiguate wording for __FILE__

### DIFF
--- a/spec/06-constants.md
+++ b/spec/06-constants.md
@@ -37,7 +37,7 @@ automatically available to all scripts; their values are not fixed:
  -----------------                | ---------                            
  `__CLASS__`                        | `string`; The name of the current class. From within a trait method, the name of the class in which that trait is used. If the current namespace is other than the default, the namespace name and "\\" are prepended, in that order. If used outside all classes, the value is the empty string. 
 `__DIR__`                            | `string`; The directory name of the script. A directory separator is only appended for the root directory.
-`__FILE__`                           | `string`; The full name of the script.
+`__FILE__`                           | `string`; The full path to the script.
 `__FUNCTION__`                       | `string`; Inside a function, the name of the current function exactly as it was declared, with the following prepended: If a named namespace exists, that namespace name followed by "\". If used outside all functions, the result is the empty string. For a method, no parent-class prefix is present. (See `__METHOD__` and [anonymous functions](15-functions.md#anonymous-functions).)
 `__LINE__`                           | `int`; the number of the current source line
 `__METHOD__`                         | `string`; Inside a method, the name of the current method exactly as it was declared, with the following prepended, in order: If a named namespace exists, that namespace name followed by "\"; the parent class name or trait name followed by `::`. If used outside all methods, the result is the same as for `__FUNCTION__`.


### PR DESCRIPTION
With the original wording, it's hard to tell whether `__FILE__` refers to just the last component of the path (sometimes called the name of a file) or the complete path.